### PR TITLE
EL - Fixed some minor textual typos

### DIFF
--- a/check.go
+++ b/check.go
@@ -16,9 +16,9 @@ const (
 // of the CheckResult.
 // Each check should implement this interface.
 
-// Check cheks some aspect of the DC/OS cluster analyzing its diagnostics
+// Check checks some aspect of the DC/OS cluster analyzing its diagnostics
 // bundle.
-// Checks can be registered in the check registry with the egisterCheck function.
+// Checks can be registered in the check registry with the registerCheck function.
 // Check is not supposed to be run more than one time.
 type Check struct {
 	Name        string               // Required

--- a/check_builder.go
+++ b/check_builder.go
@@ -6,10 +6,10 @@ import (
 
 const errName = "bun.CheckBuilder.Build: Check Name should not be empty"
 const errForEach = "bun.CheckBuilder.Build: At least one of the ForEach functions" +
-	"shoul be specified"
+	"should be specified"
 
 // MsgErr is a standard message used in the check summary when errors
-// occures during the check.
+// occurs during the check.
 const MsgErr = "Error(s) occurred while performing the check."
 
 // CheckHost checks an individual host. It returns status, details, and error if

--- a/directory.go
+++ b/directory.go
@@ -22,7 +22,7 @@ const (
 	DTRoot DirType = "root"
 	// DTMaster directory
 	DTMaster = "master"
-	// DTAgent direrctory
+	// DTAgent directory
 	DTAgent = "agent"
 	// DTPublicAgent directory
 	DTPublicAgent = "public agent"

--- a/directory_test.go
+++ b/directory_test.go
@@ -8,7 +8,7 @@ import (
 const str = `“Would you tell me, please, which way I ought to go from here?”
 “That depends a good deal on where you want to get to,” said the Cat.
 “I don’t much care where-–” said Alice.
-“Then it doesn’t matter which way you go,” said the Cat.
+“Then it doesn't matter which way you go,” said the Cat.
 “-–so long as I get SOMEWHERE,” Alice added as an explanation.
 “Oh, you’re sure to do that,” said the Cat, “if you only walk long enough.”`
 


### PR DESCRIPTION
I've resolved a few minor textual typos in the following files:
• check.go
• check_builder.go
• directory.go
• directory_test.go